### PR TITLE
Convert to UTC before saving the status

### DIFF
--- a/netkan/netkan/status.py
+++ b/netkan/netkan/status.py
@@ -44,7 +44,7 @@ class ModStatus(Model):
                 continue
             attributes[key] = getattr(self, key, None)
             if isinstance(attributes[key], datetime):
-                attributes[key] = attributes[key].isoformat()
+                attributes[key] = attributes[key].astimezone(timezone.utc).isoformat()
             elif isinstance(attributes[key], MapAttribute):
                 attributes[key] = attributes[key].as_dict()
         return attributes


### PR DESCRIPTION
If I'm not mistaken, this should always save all the time attributes in UTC, no matter where they come from and if code writing to the attributes remembers to take care of it.